### PR TITLE
Build sitemap data chatbot plugin

### DIFF
--- a/wp-chatbot-rag/assets/css/chatbot.css
+++ b/wp-chatbot-rag/assets/css/chatbot.css
@@ -1,0 +1,14 @@
+#wpcr-fab{
+	position:fixed;right:20px;bottom:20px;z-index:99999;background:#1f2937;color:#fff;border:none;border-radius:999px;padding:12px 18px;box-shadow:0 10px 20px rgba(0,0,0,.2);cursor:pointer;font-weight:600}
+#wpcr-fab:hover{background:#111827}
+#wpcr-panel{position:fixed;right:20px;bottom:80px;width:320px;max-width:90vw;height:480px;background:#ffffff;border:1px solid #e5e7eb;border-radius:16px;box-shadow:0 20px 40px rgba(0,0,0,.2);display:none;flex-direction:column;overflow:hidden;z-index:99999}
+#wpcr-panel.open{display:flex}
+#wpcr-panel .wpcr-header{padding:12px 16px;background:#111827;color:#fff;font-weight:700}
+#wpcr-panel .wpcr-messages{flex:1;padding:12px;overflow:auto;background:#f9fafb}
+#wpcr-panel .wpcr-msg{margin:8px 0;padding:10px 12px;border-radius:12px;max-width:90%}
+#wpcr-panel .wpcr-msg.user{background:#d1fae5;color:#065f46;margin-left:auto}
+#wpcr-panel .wpcr-msg.bot{background:#e5e7eb;color:#111827;margin-right:auto}
+#wpcr-panel .wpcr-input{display:flex;padding:10px;border-top:1px solid #e5e7eb;gap:8px}
+#wpcr-panel .wpcr-input input{flex:1;padding:10px 12px;border:1px solid #d1d5db;border-radius:10px}
+#wpcr-panel .wpcr-input button{background:#111827;color:#fff;border:none;border-radius:10px;padding:10px 14px;cursor:pointer}
+#wpcr-panel .wpcr-input button:hover{background:#000}

--- a/wp-chatbot-rag/assets/js/chatbot.js
+++ b/wp-chatbot-rag/assets/js/chatbot.js
@@ -1,0 +1,71 @@
+(function(){
+	function createUI(){
+		var btn = document.createElement('button');
+		btn.id = 'wpcr-fab';
+		btn.type = 'button';
+		btn.innerText = 'Chat';
+
+		var panel = document.createElement('div');
+		panel.id = 'wpcr-panel';
+		panel.innerHTML = ''+
+			'<div class="wpcr-header">'+ (WPCR && WPCR.site ? WPCR.site : 'Assistant') +'</div>'+
+			'<div class="wpcr-messages" id="wpcr-messages"></div>'+
+			'<form class="wpcr-input" id="wpcr-form">'+
+				'<input type="text" id="wpcr-text" placeholder="Ask me anything..." autocomplete="off" />'+
+				'<button type="submit">Send</button>'+
+			'</form>';
+
+		document.body.appendChild(btn);
+		document.body.appendChild(panel);
+
+		btn.addEventListener('click', function(){
+			panel.classList.toggle('open');
+		});
+
+		document.getElementById('wpcr-form').addEventListener('submit', async function(e){
+			e.preventDefault();
+			var input = document.getElementById('wpcr-text');
+			var text = input.value.trim();
+			if(!text){return;}
+			appendMessage('user', text);
+			input.value = '';
+			appendMessage('bot', '...');
+			try{
+				var res = await fetch(WPCR.root + '/chat', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-WP-Nonce': WPCR.nonce
+					},
+					body: JSON.stringify({ message: text })
+				});
+				var data = await res.json();
+				replaceLastBot(data.reply || '');
+			} catch(err){
+				replaceLastBot('Sorry, something went wrong.');
+			}
+		});
+	}
+
+	function appendMessage(role, text){
+		var list = document.getElementById('wpcr-messages');
+		var item = document.createElement('div');
+		item.className = 'wpcr-msg ' + role;
+		item.textContent = text;
+		list.appendChild(item);
+		list.scrollTop = list.scrollHeight;
+	}
+
+	function replaceLastBot(text){
+		var list = document.getElementById('wpcr-messages');
+		for(var i=list.children.length-1;i>=0;i--){
+			if(list.children[i].classList.contains('bot')){
+				list.children[i].textContent = text;
+				break;
+			}
+		}
+		list.scrollTop = list.scrollHeight;
+	}
+
+	document.addEventListener('DOMContentLoaded', createUI);
+})();

--- a/wp-chatbot-rag/includes/class-wp-chatbot-rag.php
+++ b/wp-chatbot-rag/includes/class-wp-chatbot-rag.php
@@ -1,0 +1,329 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class WP_Chatbot_RAG {
+	private static $instance = null;
+
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	private function __construct() {
+		add_action( 'init', [ $this, 'init' ] );
+		add_action( 'admin_menu', [ $this, 'register_admin_menu' ] );
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
+		add_action( 'admin_post_wpcr_crawl', [ $this, 'handle_admin_crawl' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_public_assets' ] );
+		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+	}
+
+	public static function activate() {
+		global $wpdb;
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$charset_collate = $wpdb->get_charset_collate();
+		$chunks_table = $wpdb->prefix . 'wpcr_chunks';
+
+		$sql = "CREATE TABLE {$chunks_table} (
+			id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+			url TEXT NOT NULL,
+			title TEXT NULL,
+			content LONGTEXT NOT NULL,
+			content_hash VARCHAR(64) NOT NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY  (id),
+			KEY content_hash (content_hash(10))
+		) {$charset_collate};";
+
+		dbDelta( $sql );
+	}
+
+	public static function deactivate() {
+		// Nothing for now; keep data unless uninstalled.
+	}
+
+	public function init() {
+		// Localization
+		load_plugin_textdomain( 'wp-chatbot-rag', false, dirname( plugin_basename( WP_CHATBOT_RAG_PATH . 'wp-chatbot-rag.php' ) ) . '/languages' );
+	}
+
+	public function enqueue_public_assets() {
+		wp_register_style( 'wpcr-chatbot', WP_CHATBOT_RAG_URL . 'assets/css/chatbot.css', [], WP_CHATBOT_RAG_VERSION );
+		wp_register_script( 'wpcr-chatbot', WP_CHATBOT_RAG_URL . 'assets/js/chatbot.js', [ 'wp-api-fetch' ], WP_CHATBOT_RAG_VERSION, true );
+
+		wp_enqueue_style( 'wpcr-chatbot' );
+		wp_enqueue_script( 'wpcr-chatbot' );
+
+		wp_localize_script( 'wpcr-chatbot', 'WPCR', [
+			'root'   => esc_url_raw( rest_url( 'wp-chatbot-rag/v1' ) ),
+			'nonce'  => wp_create_nonce( 'wp_rest' ),
+			'site'   => get_bloginfo( 'name' ),
+			'avatar' => get_avatar_url( get_current_user_id() ),
+		] );
+	}
+
+	public function register_admin_menu() {
+		add_menu_page(
+			__( 'Chatbot RAG', 'wp-chatbot-rag' ),
+			__( 'Chatbot RAG', 'wp-chatbot-rag' ),
+			'manage_options',
+			'wpcr-settings',
+			[ $this, 'render_settings_page' ],
+			'dashicons-format-chat'
+		);
+	}
+
+	public function register_settings() {
+		register_setting( 'wpcr_settings', 'wpcr_openai_api_key', [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ] );
+		register_setting( 'wpcr_settings', 'wpcr_sitemap_url', [ 'type' => 'string', 'sanitize_callback' => 'esc_url_raw' ] );
+	}
+
+	public function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$api_key = get_option( 'wpcr_openai_api_key', '' );
+		$sitemap = get_option( 'wpcr_sitemap_url', home_url( '/sitemap.xml' ) );
+		$action_url = admin_url( 'admin-post.php' );
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Chatbot RAG Assistant', 'wp-chatbot-rag' ); ?></h1>
+			<form method="post" action="options.php">
+				<?php settings_fields( 'wpcr_settings' ); ?>
+				<table class="form-table" role="presentation">
+					<tr>
+						<th scope="row"><label for="wpcr_openai_api_key"><?php esc_html_e( 'OpenAI API Key (optional)', 'wp-chatbot-rag' ); ?></label></th>
+						<td><input type="password" id="wpcr_openai_api_key" name="wpcr_openai_api_key" value="<?php echo esc_attr( $api_key ); ?>" class="regular-text" /></td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="wpcr_sitemap_url"><?php esc_html_e( 'Sitemap URL', 'wp-chatbot-rag' ); ?></label></th>
+						<td><input type="url" id="wpcr_sitemap_url" name="wpcr_sitemap_url" value="<?php echo esc_attr( $sitemap ); ?>" class="regular-text" required /></td>
+					</tr>
+				</table>
+				<?php submit_button(); ?>
+			</form>
+
+			<hr />
+
+			<form method="post" action="<?php echo esc_url( $action_url ); ?>">
+				<?php wp_nonce_field( 'wpcr_crawl' ); ?>
+				<input type="hidden" name="action" value="wpcr_crawl" />
+				<?php submit_button( __( 'Crawl Sitemap Now', 'wp-chatbot-rag' ), 'primary' ); ?>
+			</form>
+		</div>
+		<?php
+	}
+
+	public function handle_admin_crawl() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( __( 'Unauthorized', 'wp-chatbot-rag' ) );
+		}
+		check_admin_referer( 'wpcr_crawl' );
+
+		$this->crawl_sitemap();
+
+		wp_safe_redirect( add_query_arg( [ 'wpcr_crawled' => '1' ], admin_url( 'admin.php?page=wpcr-settings' ) ) );
+		exit;
+	}
+
+	private function crawl_sitemap() {
+		$sitemap_url = get_option( 'wpcr_sitemap_url', home_url( '/sitemap.xml' ) );
+		$response = wp_remote_get( $sitemap_url, [ 'timeout' => 20 ] );
+		if ( is_wp_error( $response ) ) {
+			return;
+		}
+		$body = wp_remote_retrieve_body( $response );
+		if ( empty( $body ) ) {
+			return;
+		}
+
+		$urls = $this->extract_urls_from_sitemap( $body );
+		if ( empty( $urls ) ) {
+			return;
+		}
+		foreach ( $urls as $url ) {
+			$this->index_url( $url );
+		}
+	}
+
+	private function extract_urls_from_sitemap( $xml_string ) {
+		$urls = [];
+		libxml_use_internal_errors( true );
+		$xml = simplexml_load_string( $xml_string );
+		if ( ! $xml ) {
+			return $urls;
+		}
+		$xml->registerXPathNamespace( 'sm', 'http://www.sitemaps.org/schemas/sitemap/0.9' );
+
+		// If it's a sitemap index
+		$index_entries = $xml->xpath( '//sm:sitemap/sm:loc' );
+		if ( ! empty( $index_entries ) ) {
+			foreach ( $index_entries as $loc ) {
+				$child_resp = wp_remote_get( (string) $loc );
+				if ( ! is_wp_error( $child_resp ) ) {
+					$child_body = wp_remote_retrieve_body( $child_resp );
+					$urls = array_merge( $urls, $this->extract_urls_from_sitemap( $child_body ) );
+				}
+			}
+			return array_values( array_unique( $urls ) );
+		}
+
+		// Regular urlset
+		$url_entries = $xml->xpath( '//sm:url/sm:loc' );
+		foreach ( $url_entries as $loc ) {
+			$urls[] = (string) $loc;
+		}
+		return array_values( array_unique( $urls ) );
+	}
+
+	private function index_url( $url ) {
+		$response = wp_remote_get( $url, [ 'timeout' => 20 ] );
+		if ( is_wp_error( $response ) ) {
+			return;
+		}
+		$html = wp_remote_retrieve_body( $response );
+		if ( empty( $html ) ) {
+			return;
+		}
+
+		$title = $this->extract_title( $html );
+		$text  = $this->extract_text_content( $html );
+		if ( empty( $text ) ) {
+			return;
+		}
+
+		$chunks = $this->split_into_chunks( $text, 1200, 200 );
+		foreach ( $chunks as $chunk ) {
+			$this->upsert_chunk( $url, $title, $chunk );
+		}
+	}
+
+	private function extract_title( $html ) {
+		if ( preg_match( '/<title>(.*?)<\\/title>/is', $html, $m ) ) {
+			return wp_strip_all_tags( html_entity_decode( $m[1], ENT_QUOTES | ENT_HTML5 ) );
+		}
+		return '';
+	}
+
+	private function extract_text_content( $html ) {
+		$dom = new DOMDocument();
+		libxml_use_internal_errors( true );
+		$dom->loadHTML( $html );
+		$xpath = new DOMXPath( $dom );
+
+		// Remove scripts, styles, nav, footer
+		foreach ( [ 'script', 'style', 'nav', 'footer', 'noscript' ] as $tag ) {
+			foreach ( $dom->getElementsByTagName( $tag ) as $node ) {
+				$node->parentNode->removeChild( $node );
+			}
+		}
+		$body_nodes = $xpath->query( '//body' );
+		$content = '';
+		if ( $body_nodes->length > 0 ) {
+			$content = $body_nodes->item(0)->textContent;
+		}
+		$content = preg_replace( '/\s+/', ' ', $content );
+		return trim( $content );
+	}
+
+	private function split_into_chunks( $text, $max_len, $overlap ) {
+		$chunks = [];
+		$length = strlen( $text );
+		$start  = 0;
+		while ( $start < $length ) {
+			$end = min( $start + $max_len, $length );
+			$chunks[] = substr( $text, $start, $end - $start );
+			if ( $end === $length ) {
+				break;
+			}
+			$start = $end - $overlap;
+			if ( $start < 0 ) {
+				$start = 0;
+			}
+		}
+		return $chunks;
+	}
+
+	private function upsert_chunk( $url, $title, $content ) {
+		global $wpdb;
+		$table = $wpdb->prefix . 'wpcr_chunks';
+		$hash  = md5( $url . '|' . $content );
+		$now   = current_time( 'mysql' );
+
+		$existing = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE content_hash = %s", $hash ) );
+		if ( $existing ) {
+			$wpdb->update( $table, [
+				'url'         => $url,
+				'title'       => $title,
+				'content'     => $content,
+				'updated_at'  => $now,
+			], [ 'id' => $existing ] );
+			return;
+		}
+
+		$wpdb->insert( $table, [
+			'url'        => $url,
+			'title'      => $title,
+			'content'    => $content,
+			'content_hash' => $hash,
+			'created_at' => $now,
+			'updated_at' => $now,
+		] );
+	}
+
+	public function register_rest_routes() {
+		register_rest_route( 'wp-chatbot-rag/v1', '/chat', [
+			'methods'  => 'POST',
+			'permission_callback' => '__return_true',
+			'args' => [
+				'message' => [ 'type' => 'string', 'required' => true ],
+			],
+			'callback' => [ $this, 'rest_chat' ],
+		] );
+	}
+
+	public function rest_chat( WP_REST_Request $request ) {
+		$message = sanitize_text_field( $request->get_param( 'message' ) );
+		if ( strlen( $message ) < 3 ) {
+			return new WP_REST_Response( [ 'reply' => __( 'Please provide more detail.', 'wp-chatbot-rag' ) ], 200 );
+		}
+
+		$context = $this->search_chunks_by_keyword( $message, 5 );
+		$reply = $this->compose_answer_from_context( $message, $context );
+
+		return new WP_REST_Response( [ 'reply' => $reply, 'sources' => $context ], 200 );
+	}
+
+	private function search_chunks_by_keyword( $query, $limit = 5 ) {
+		global $wpdb;
+		$table = $wpdb->prefix . 'wpcr_chunks';
+		$like = '%' . $wpdb->esc_like( $query ) . '%';
+		$rows = $wpdb->get_results( $wpdb->prepare(
+			"SELECT url, title, content FROM {$table} WHERE content LIKE %s OR title LIKE %s ORDER BY updated_at DESC LIMIT %d",
+			$like, $like, $limit
+		), ARRAY_A );
+		return is_array( $rows ) ? $rows : [];
+	}
+
+	private function compose_answer_from_context( $question, $context_rows ) {
+		if ( empty( $context_rows ) ) {
+			return __( 'I could not find information on that yet. Try rephrasing or check back after the site has been indexed.', 'wp-chatbot-rag' );
+		}
+		$snippets = array_map( function( $row ) {
+			$excerpt = mb_substr( $row['content'], 0, 320 );
+			return sprintf( "%s — %s", $excerpt, $row['url'] );
+		}, $context_rows );
+
+		$answer = __( 'Here is what I found related to your question:', 'wp-chatbot-rag' ) . "\n\n" . implode( "\n\n", $snippets );
+		return $answer;
+	}
+}
+

--- a/wp-chatbot-rag/wp-chatbot-rag.php
+++ b/wp-chatbot-rag/wp-chatbot-rag.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Plugin Name: Chatbot RAG Assistant
+ * Description: Floating chatbot that indexes your sitemap and answers questions using your site content.
+ * Version: 0.1.0
+ * Author: You
+ * License: GPLv2 or later
+ * Text Domain: wp-chatbot-rag
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'WP_CHATBOT_RAG_VERSION' ) ) {
+	define( 'WP_CHATBOT_RAG_VERSION', '0.1.0' );
+}
+
+if ( ! defined( 'WP_CHATBOT_RAG_PATH' ) ) {
+	define( 'WP_CHATBOT_RAG_PATH', plugin_dir_path( __FILE__ ) );
+}
+
+if ( ! defined( 'WP_CHATBOT_RAG_URL' ) ) {
+	define( 'WP_CHATBOT_RAG_URL', plugin_dir_url( __FILE__ ) );
+}
+
+require_once WP_CHATBOT_RAG_PATH . 'includes/class-wp-chatbot-rag.php';
+
+function wp_chatbot_rag() {
+	return WP_Chatbot_RAG::instance();
+}
+
+register_activation_hook( __FILE__, [ 'WP_Chatbot_RAG', 'activate' ] );
+register_deactivation_hook( __FILE__, [ 'WP_Chatbot_RAG', 'deactivate' ] );
+
+wp_chatbot_rag();


### PR DESCRIPTION
Create the initial WordPress chatbot RAG plugin scaffold, enabling sitemap crawling, content indexing, and a basic keyword-search response mechanism via a modern chat UI.

This PR establishes the core plugin structure, admin settings for sitemap URL and an optional OpenAI API key, and the functionality to crawl a sitemap, extract content, and store it in a database. The frontend chat UI and REST API are implemented, with the current RAG flow providing keyword-based answers from the indexed content.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b041d99-897e-493a-8528-66df035da85f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b041d99-897e-493a-8528-66df035da85f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

